### PR TITLE
Add packaging for MCP servers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Alex Stansfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Casual MCP Servers
+
+This repository contains a collection of Micro Code Pilot (MCP) servers. Each server is available as a standalone Python package on PyPI. See the individual directories at the repository root for more details.

--- a/math/README.md
+++ b/math/README.md
@@ -1,0 +1,3 @@
+# casual-mcp-server-math
+
+This package provides math and conversion utilities as a [FastMCP](https://github.com/codex-datasets/fastmcp) server.

--- a/math/casual_mcp_server_math/__init__.py
+++ b/math/casual_mcp_server_math/__init__.py
@@ -99,5 +99,13 @@ def round_number(
 #     return pairs
 
 
-if __name__ == "__main__":
+
+
+
+def main() -> None:
+    """Run the Math MCP server."""
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/math/pyproject.toml
+++ b/math/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "casual-mcp-server-math"
+version = "0.1.0"
+description = "Math and conversion utilities as a FastMCP server"
+authors = [{name = "Alex Stansfield"}]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+dependencies = [
+    "fastmcp",
+    "pydantic",
+]
+
+[project.urls]
+Homepage = "https://github.com/alexstansfield/casual-mcp-servers"
+Issues = "https://github.com/alexstansfield/casual-mcp-servers/issues"
+Source = "https://github.com/alexstansfield/casual-mcp-servers"
+
+[project.scripts]
+casual-mcp-server-math = "casual_mcp_server_math:main"

--- a/time/README.md
+++ b/time/README.md
@@ -1,0 +1,3 @@
+# casual-mcp-server-time
+
+This package provides a collection of time and date utilities as a [FastMCP](https://github.com/codex-datasets/fastmcp) server.

--- a/time/casual_mcp_server_time/__init__.py
+++ b/time/casual_mcp_server_time/__init__.py
@@ -101,5 +101,13 @@ def parse_human_date(
         raise ValueError("Could not parse the date description.")
     return parsed.date().isoformat()
 
-if __name__ == "__main__":
+
+
+
+def main() -> None:
+    """Run the Time MCP server."""
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/time/pyproject.toml
+++ b/time/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "casual-mcp-server-time"
+version = "0.1.0"
+description = "Time and date utilities as a FastMCP server"
+authors = [{name = "Alex Stansfield"}]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+dependencies = [
+    "fastmcp",
+    "pydantic",
+    "dateparser",
+]
+
+[project.urls]
+Homepage = "https://github.com/alexstansfield/casual-mcp-servers"
+Issues = "https://github.com/alexstansfield/casual-mcp-servers/issues"
+Source = "https://github.com/alexstansfield/casual-mcp-servers"
+
+[project.scripts]
+casual-mcp-server-time = "casual_mcp_server_time:main"

--- a/weather/README.md
+++ b/weather/README.md
@@ -1,0 +1,3 @@
+# casual-mcp-server-weather
+
+This package provides weather forecast and air quality utilities using Open-Meteo as a [FastMCP](https://github.com/codex-datasets/fastmcp) server.

--- a/weather/casual_mcp_server_weather/__init__.py
+++ b/weather/casual_mcp_server_weather/__init__.py
@@ -134,5 +134,13 @@ def air_quality(location: Annotated[str, Field(description="City or place name")
         "time": hourly.get("time", [None])[latest]
     }
 
-if __name__ == "__main__":
+
+
+
+def main() -> None:
+    """Run the Weather MCP server."""
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/weather/pyproject.toml
+++ b/weather/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "casual-mcp-server-weather"
+version = "0.1.0"
+description = "Weather and air quality utilities as a FastMCP server"
+authors = [{name = "Alex Stansfield"}]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+dependencies = [
+    "fastmcp",
+    "pydantic",
+    "requests",
+]
+
+[project.urls]
+Homepage = "https://github.com/alexstansfield/casual-mcp-servers"
+Issues = "https://github.com/alexstansfield/casual-mcp-servers/issues"
+Source = "https://github.com/alexstansfield/casual-mcp-servers"
+
+[project.scripts]
+casual-mcp-server-weather = "casual_mcp_server_weather:main"

--- a/words/README.md
+++ b/words/README.md
@@ -1,0 +1,3 @@
+# casual-mcp-server-words
+
+This package provides dictionary and thesaurus utilities using the Free Dictionary API as a [FastMCP](https://github.com/codex-datasets/fastmcp) server.

--- a/words/casual_mcp_server_words/__init__.py
+++ b/words/casual_mcp_server_words/__init__.py
@@ -64,5 +64,13 @@ def synonyms(
     return list(synonyms_set)
 
 
-if __name__ == "__main__":
+
+
+
+def main() -> None:
+    """Run the Words MCP server."""
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/words/pyproject.toml
+++ b/words/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "casual-mcp-server-words"
+version = "0.1.0"
+description = "Dictionary and thesaurus utilities as a FastMCP server"
+authors = [{name = "Alex Stansfield"}]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+dependencies = [
+    "fastmcp",
+    "pydantic",
+    "requests",
+]
+
+[project.urls]
+Homepage = "https://github.com/alexstansfield/casual-mcp-servers"
+Issues = "https://github.com/alexstansfield/casual-mcp-servers/issues"
+Source = "https://github.com/alexstansfield/casual-mcp-servers"
+
+[project.scripts]
+casual-mcp-server-words = "casual_mcp_server_words:main"


### PR DESCRIPTION
## Summary
- convert each server into a Python package so they can be published to PyPI
- add MIT license and repo README
- add build scripts for `casual-mcp-server-*` packages
- move server packages to repo root as requested

## Testing
- `pip install build`
- `python -m build` in `math`
- `python -m build` in `time`
- `python -m build` in `weather`
- `python -m build` in `words`


------
https://chatgpt.com/codex/tasks/task_e_6846958ab0508329bab5e92bf47c616b